### PR TITLE
Remove leading dot in section name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Requires a small addition to the linker script. A full script isn't included her
 Find the linker script suitable for the AVR in question, then add these four lines somewhere in the .text section:
 ```
 PROVIDE (__cmdtable_start = .) ;
-*(SORT_BY_NAME(.cmdtable*))
+*(SORT_BY_NAME(cmdtable*))
 PROVIDE (__cmdtable_end = .) ;
-KEEP(*(.cmdtable*))
+KEEP(*(cmdtable*))
 ```
 The recommended placement is after .ctors and .dtors, and before .init0
 

--- a/cmd.h
+++ b/cmd.h
@@ -23,7 +23,7 @@ typedef struct
 static const __flash char cmdname##Name[] = #cmdname; \
 static const __flash char cmdname##Help[] = #cmdhelp; \
 static const cmdlist_t cmdname##CmdTableEntry \
-__attribute__((used, section(".cmdtable." #cmdname))) = { \
+__attribute__((used, section("cmdtable." #cmdname))) = { \
     .name = cmdname##Name, \
     .help = cmdname##Help, \
     .func = cmdname##Cmd \


### PR DESCRIPTION
Leading dot in sections are reserved for system, so don't use it