### PR TITLE
Linker script changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c text
+*.cpp text
+*.h text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.atsln text eol=crlf
+*.sln text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.bin binary
+
+# Files with LF only (also in Windows)
+*.ld text eol=lf
+

--- a/README.md
+++ b/README.md
@@ -1,28 +1,19 @@
 # avr-shell-cmd
 Small helper library for creating shell commands on an AVR, when using avr-gcc.
-Requires a small addition to the linker script. A full script isn't included here, as it changes depending on which AVR is used.
+Requires adding an augmented linker script.
 
-## Linker script modifications
-Find the linker script suitable for the AVR in question, then add these five lines somewhere in the .text section:
+## Linker script augmentation
+This repository includes an augmented linker script: `cmdtables.ld`. Tell the linker to augment the linker script with this file (use the -T command line option). In Atmel/Microchip Studio this is done in the project properties (Alt+F7), Toolchain, AVR/GNU Linker, Miscellaneous, Other Linker Flags. Add the line:
 ```
-PROVIDE (__cmdtable_start = .) ;
-*(SORT_BY_NAME(cmdtable*))
-PROVIDE (__cmdtable_end = .) ;
-KEEP(*(cmdtable*))
-. = ALIGN(2);
+-T $(ProjectDir)\lib\avr-shell-cmd\cmdtables.ld
 ```
-The recommended placement is after .ctors and .dtors, and before .init0
-
-Then tell the linker to use the modified linker script (use the -T command line option). In Atmel/Microchip Studio this is done in the project properties (Alt+F7), Toolchain, AVR/GNU Linker, Miscellaneous, Other Linker Flags. Add the line:
-```
--T $(ProjectDir)\avrxmega4.x
-```
-Change the path and filename to match your modified linker script.
+Change the path to match where you've included this repo.
 
 If you don't use Atmel/Microchip Studio, add the linker option in your makefile.
 
 ## Using avr-shell-cmd
-First, include the files here in your build. This repo can be included as a submodule.
+First, include the files here in your build. This repo can be included as a submodule.  
+Then add the linker script as described above.
 
 ### Creating a shell command
 Wherever you want a shell command, include cmd.h. Then make a static function with the command you want (name it the command followed by "Cmd"), and then put it in a CMD macro. Here is a command called "example":

--- a/cmd.c
+++ b/cmd.c
@@ -11,12 +11,20 @@
 #include <string.h>
 #include "cmd.h"
 
-extern const __flash cmdlist_t __cmdtable_start;
-extern const __flash cmdlist_t __cmdtable_end;
+#ifdef __AVR_HAVE_ELPMX__
+// AVR supports ELPM with Z+ so cmdtable may be located above 64KB. Use 24-bit pointer
+#define TABLEMEM __memx
+#else
+// AVR doesn't support data in flash above 64KB. Use normal 16-bit pointer
+#define TABLEMEM __flash
+#endif
+
+extern const TABLEMEM cmdlist_t __cmdtable_start;
+extern const TABLEMEM cmdlist_t __cmdtable_end;
 
 static void helpCmd(uint8_t argc, char *argv[])
 {
-    const __flash cmdlist_t *p = &__cmdtable_start;
+    const TABLEMEM cmdlist_t *p = &__cmdtable_start;
 
     while (p < &__cmdtable_end)
     {
@@ -30,7 +38,7 @@ CMD(help, "This help");
 
 void cmd_exec(uint8_t argc, char *argv[])
 {
-    const __flash cmdlist_t *p = &__cmdtable_start;
+    const TABLEMEM cmdlist_t *p = &__cmdtable_start;
 
     while (p < &__cmdtable_end)
     {

--- a/cmdtables.ld
+++ b/cmdtables.ld
@@ -1,0 +1,15 @@
+/* Linker script augmentation */
+
+SECTIONS
+{
+  cmdtables :
+  {
+    PROVIDE (__cmdtable_start = .) ;
+    *(SORT_BY_NAME(cmdtable*))
+    PROVIDE (__cmdtable_end = .) ;
+    KEEP(*(cmdtable*))
+    . = ALIGN(2);
+  }
+}
+
+INSERT AFTER .text


### PR DESCRIPTION
Instead of using a modified full linker script, which changes depending of the AVR model, augment the existing linker script. As this changes the placement of the cmdtable to the end of the program in flash, also add support for having the table above the 64KB limit of __flash.